### PR TITLE
Polymorphic belongs_to breaks archival

### DIFF
--- a/lib/expected_behavior/acts_as_archival.rb
+++ b/lib/expected_behavior/acts_as_archival.rb
@@ -116,7 +116,7 @@ module ExpectedBehavior
         self.class.reflect_on_all_associations.each do |association|
 #           puts "0.1 - #{association.klass.name}"
 #           puts "0.2 - #{association.options.inspect}"
-          if association.klass.is_archival? && association.macro.to_s =~ /^has/ && options[:association_options].call(association) && association.options[:through].nil?
+          if association.macro.to_s =~ /^has/ && association.klass.is_archival? && options[:association_options].call(association) && association.options[:through].nil?
             act_on_a_related_archival(association.klass, association.primary_key_name, id, head_archive_number, options)
           end
         end

--- a/test/acts_as_archival_test.rb
+++ b/test/acts_as_archival_test.rb
@@ -224,6 +224,14 @@ class ActsAsArchivalTest < ActiveSupport::TestCase
     assert @hole.muskrats.first.reload.archived?
     assert @hole.muskrats.first.fleas.first.archived?
   end
+
+  test "archiving items with polymorphic associations succeeds" do
+    @muskrat = Muskrat.create(:name => "Algernon")
+    @tick = Tick.create
+    @muskrat.ixodidaes.create(:tick => @tick)
+    @muskrat.archive
+    assert @muskrat.reload.archived?
+  end
   
   test "unarchiving deeply nested items doesn't blow up" do
     @hole.muskrats.first.fleas << Flea.create(:name => "Wadsworth")

--- a/test/ixodidae.rb
+++ b/test/ixodidae.rb
@@ -1,0 +1,6 @@
+class Ixodidae < ActiveRecord::Base
+  acts_as_archival
+
+  belongs_to :tick
+  belongs_to :warm_blodded, :polymorphic => true
+end

--- a/test/muskrat.rb
+++ b/test/muskrat.rb
@@ -4,6 +4,9 @@ class Muskrat < ActiveRecord::Base
   belongs_to :hole
   has_many :fleas, :dependent => :destroy
   
+  has_many :ixodidaes, :as => :warm_blooded, :dependent => :destroy
+  has_many :ticks, :through => :ixodidaes
+
   validate :invalid_for_certain_names
   
   def invalid_for_certain_names

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -73,4 +73,17 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string   :archive_number
     t.datetime :archived_at
   end
+
+  create_table :ticks, :force => true do |t|
+    t.string :archive_number
+    t.datetime :archived_at
+  end
+
+  create_table :ixodidaes, :force => true do |t|
+    t.references :ticks
+    t.integer :warm_blooded_id
+    t.string :warm_blooded_type
+    t.string :archive_number
+    t.datetime :archived_at
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ end
 require 'rails/test_help'
 require 'assertions'
 
-%w(hole mole muskrat squirrel kitty puppy ship rat orange flea snake beaver).each do |a|
+%w(hole mole muskrat squirrel kitty puppy ship rat orange flea snake beaver tick ixodidae).each do |a|
   require File.expand_path(File.dirname(__FILE__) + "/" + a)
 end
 

--- a/test/tick.rb
+++ b/test/tick.rb
@@ -1,0 +1,5 @@
+class Tick < ActiveRecord::Base
+  acts_as_archival
+
+  has_many :ixodidae # Here the whole join-table polymorph analogy totally breaks down... sorry
+end


### PR DESCRIPTION
This contains an extra test & the fix to prevent this happening.

If a model has a belongs_to :polymorphic association on it and is also archival, the archive fails silently.
