### PR TITLE
Fix define_callbacks call

### DIFF
--- a/lib/expected_behavior/acts_as_archival.rb
+++ b/lib/expected_behavior/acts_as_archival.rb
@@ -26,8 +26,8 @@ module ExpectedBehavior
           scope :archived_from_archive_number, lambda { |head_archive_number| {:conditions => ['archived_at IS NOT NULL AND archive_number = ?', head_archive_number] } }
        
           callbacks = ['archive','unarchive']
-          define_callbacks *[callbacks, {:terminator => 'result == false'}].flatten
           callbacks.each do |callback|
+            define_callbacks(callback, {:terminator => 'result == false'})
             eval <<-end_callbacks
               def before_#{callback}(*args, &blk)
                 set_callback(:#{callback}, :before, *args, &blk)


### PR DESCRIPTION
This was causing callbacks to be both before and after callbacks when set.

With the previous version, whilst spying on a method call, it was being called twice -- before and after, instead of only after. This patch fixes that, and the tests in this Rails 3.0.12 app now pass. 

That said, I must admit I was unable to get the tests working in this branch of AAA, after several tries. I know: I'm terrible.
