### PR TITLE
Fixing callbacks for Rails 4

### DIFF
--- a/lib/expected_behavior/acts_as_archival.rb
+++ b/lib/expected_behavior/acts_as_archival.rb
@@ -64,15 +64,15 @@ module ExpectedBehavior
       def archive(head_archive_number=nil)
         self.class.transaction do
           begin
-            run_callbacks :archive, :before
-            unless self.archived?
-              head_archive_number ||= Digest::MD5.hexdigest("#{self.class.name}#{self.id}")
-              self.archive_associations(head_archive_number)
-              self.archived_at = DateTime.now
-              self.archive_number = head_archive_number
-              self.save!
+            run_callbacks :archive do
+              unless self.archived?
+                head_archive_number ||= Digest::MD5.hexdigest("#{self.class.name}#{self.id}")
+                self.archive_associations(head_archive_number)
+                self.archived_at = DateTime.now
+                self.archive_number = head_archive_number
+                self.save!
+              end
             end
-            run_callbacks :archive, :after
             return true
           rescue => e
             ActiveRecord::Base.logger.try(:debug, e.message)


### PR DESCRIPTION
Hi, thanks for a great project!  I'm on rails 4 beta / ruby 2 and got: 

wrong number of arguments (2 for 1) from acts_as_archival.rb:67

In http://edgeapi.rubyonrails.org/classes/ActiveSupport/Callbacks.html and source, looks like run_callbacks now only takes the callback name and a block, and handles before/around/after automatically.

Patched and ran the tests - they all pass.

Cheers,
James
