### PR TITLE
Make #archived? report true/false instead of truthy/nil.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes!
 
+## Unreleased
+* make `#archived?` return an actual boolean value
+
 ## 0.6.1
 * Fix deprecation warnings on Rails 4.1
 * Test suite now runs against multiple versions of Rails

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ i.e. `rails g migration AddAAAToPost archive_number archived_at:datetime`
 
 Any dependent-destroy AAA model associated to an AAA model will be archived with its parent.
 
-_If you're stuck on Rails 3.0x/2, check out the available branches, which are no longer in active development._
+_If you're stuck on Rails 3x/2x, check out the available branches, which are no longer in active development._
 
 ## Example
 
@@ -52,7 +52,7 @@ end
 h = Hole.create                  #
 h.archived?                      # => false
 h.archive                        # => true
-h.archived?                      # => "b56876de48a5dcfe71b2c13eec15e4a2"
+h.archived?                      # => true
 h.archive_number                 # => "b56876de48a5dcfe71b2c13eec15e4a2"
 h.archived_at                    # => Thu, 01 Jan 2012 01:49:21 -0400
 h.unarchive                      # => true
@@ -69,7 +69,7 @@ r = h.rats.create                #
 h.archive                        # => true
 h.archive_number                 # => "b56876de48a5dcfe71b2c13eec15e4a2"
 r.archive_number                 # => "b56876de48a5dcfe71b2c13eec15e4a2"
-r.archived?                      # => "b56876de48a5dcfe71b2c13eec15e4a2"
+r.archived?                      # => true
 h.unarchive                      # => true
 h.archive_number                 # => nil
 r.archive_number                 # => nil

--- a/lib/expected_behavior/acts_as_archival.rb
+++ b/lib/expected_behavior/acts_as_archival.rb
@@ -55,7 +55,7 @@ module ExpectedBehavior
       end
 
       def archived?
-        self.archived_at? && self.archive_number
+        !!(self.archived_at? && self.archive_number)
       end
 
       def archive(head_archive_number=nil)

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -4,13 +4,13 @@ class BasicTest < ActiveSupport::TestCase
   test "archive archives the record" do
     archival = Archival.create!
     archival.archive
-    assert archival.reload.archived?
+    assert_equal true, archival.reload.archived?
   end
 
   test "unarchive unarchives archival records" do
     archival = Archival.create!(:archived_at => Time.now, :archive_number => 1)
     archival.unarchive
-    assert_not archival.reload.archived?
+    assert_equal false, archival.reload.archived?
   end
 
   test "archive returns true on success" do


### PR DESCRIPTION
Fixes #20 

Requires major number version update, since this is not technically backward compatible API change