### PR TITLE
use active record where.not instead of hand-building SQL

### DIFF
--- a/lib/expected_behavior/acts_as_archival.rb
+++ b/lib/expected_behavior/acts_as_archival.rb
@@ -18,7 +18,7 @@ module ExpectedBehavior
           before_validation :raise_if_not_archival
           validate :readonly_when_archived if options[:readonly_when_archived]
 
-          scope :archived, lambda { where %Q{#{self.table_name}.archived_at IS NOT NULL AND #{self.table_name}.archive_number IS NOT NULL} }
+          scope :archived, lambda { where.not(:archived_at => nil, :archive_number => nil) }
           scope :unarchived, lambda { where(:archived_at => nil, :archive_number => nil) }
           scope :archived_from_archive_number, lambda { |head_archive_number| where(['archived_at IS NOT NULL AND archive_number = ?', head_archive_number]) }
 

--- a/test/scope_test.rb
+++ b/test/scope_test.rb
@@ -49,7 +49,7 @@ class ScopeTest < ActiveSupport::TestCase
   end
 
   test "table_name is set to 'legacy'" do
-    archived_sql = %Q{SELECT "legacy".* FROM "legacy"  WHERE (legacy.archived_at IS NOT NULL AND legacy.archive_number IS NOT NULL)}
+    archived_sql = %Q{SELECT "legacy".* FROM "legacy"#  WHERE ("legacy"."archived_at" IS NOT NULL) AND ("legacy"."archive_number" IS NOT NULL)}
     unarchived_sql = %Q{SELECT "legacy".* FROM "legacy"  WHERE "legacy"."archived_at" IS NULL AND "legacy"."archive_number" IS NULL}
     assert_equal archived_sql, ArchivalTableName.archived.to_sql
     assert_equal unarchived_sql, ArchivalTableName.unarchived.to_sql

--- a/test/scope_test.rb
+++ b/test/scope_test.rb
@@ -49,7 +49,7 @@ class ScopeTest < ActiveSupport::TestCase
   end
 
   test "table_name is set to 'legacy'" do
-    archived_sql = %Q{SELECT "legacy".* FROM "legacy"#  WHERE ("legacy"."archived_at" IS NOT NULL) AND ("legacy"."archive_number" IS NOT NULL)}
+    archived_sql = %Q{SELECT "legacy".* FROM "legacy"  WHERE ("legacy"."archived_at" IS NOT NULL) AND ("legacy"."archive_number" IS NOT NULL)}
     unarchived_sql = %Q{SELECT "legacy".* FROM "legacy"  WHERE "legacy"."archived_at" IS NULL AND "legacy"."archive_number" IS NULL}
     assert_equal archived_sql, ArchivalTableName.archived.to_sql
     assert_equal unarchived_sql, ArchivalTableName.unarchived.to_sql


### PR DESCRIPTION
Fixes #18 

This cannot be rolled out until we drop mainline support for rails 3 (AKA #21), because `.not` was added in rails 4.0.

Probably should release it alongside #21 and #22 as one big crazy release.