### PR TITLE
Fix archival of polymorphic association of another model with same id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
+  - 2.5.1
 
 gemfile:
   - gemfiles/rails_4.1.gemfile
@@ -29,4 +30,6 @@ matrix:
     - rvm: 2.1.10
       gemfile: gemfiles/rails_5.1.gemfile
     - rvm: 2.4.0
+      gemfile: gemfiles/rails_4.1.gemfile
+    - rvm: 2.5.1
       gemfile: gemfiles/rails_4.1.gemfile

--- a/acts_as_archival.gemspec
+++ b/acts_as_archival.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "database_cleaner"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rr"
-  gem.add_development_dependency "sqlite3"
+  gem.add_development_dependency "sqlite3", "~> 1.3.0"
   gem.add_development_dependency "rubocop", "~> 0.47.1"
 
   gem.description = <<-END

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/expected_behavior/association_operation/base.rb
+++ b/lib/expected_behavior/association_operation/base.rb
@@ -36,7 +36,9 @@ module ExpectedBehavior
 
         def act_on_association(association)
           key = association.respond_to?(:foreign_key) ? association.foreign_key : association.primary_key_name
-          scope = association.klass.where(key => model.id)
+          scope_conditions = { key => model.id }
+          scope_conditions[association.type] = model.class.base_class.name if association.type # polymorphic association case
+          scope = association.klass.where(scope_conditions)
           act_on_archivals(scope)
         end
 

--- a/test/fixtures/another_polys_holder.rb
+++ b/test/fixtures/another_polys_holder.rb
@@ -1,0 +1,11 @@
+# name           - string
+# archival_id    - integer
+# archive_number - string
+# archived_at    - datetime
+class AnotherPolysHolder < ActiveRecord::Base
+
+  acts_as_archival
+
+  has_many :polys, dependent: :destroy, as: :archiveable
+
+end

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -11,6 +11,15 @@ class PolymorphicTest < ActiveSupport::TestCase
     assert poly.reload.archived?
   end
 
+  test "does not archive polymorphic association of different item with same id" do
+    archival = Archival.create!
+    another_polys_holder = AnotherPolysHolder.create! id: archival.id
+    poly = another_polys_holder.polys.create!
+    archival.archive!
+
+    assert_not poly.reload.archived?
+  end
+
   test "unarchive item with polymorphic association" do
     archive_attributes = {
       archive_number: "test",
@@ -22,6 +31,20 @@ class PolymorphicTest < ActiveSupport::TestCase
 
     assert_not archival.reload.archived?
     assert_not poly.reload.archived?
+  end
+
+  test "does not unarchive polymorphic association of different item with same id" do
+    archive_attributes = {
+      archive_number: "test",
+      archived_at: Time.now
+    }
+
+    archival = Archival.create!(archive_attributes)
+    another_polys_holder = AnotherPolysHolder.create!(archive_attributes.merge(id: archival.id))
+    poly = another_polys_holder.polys.create!(archive_attributes)
+    archival.unarchive!
+
+    assert poly.reload.archived?
   end
 
 end

--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -13,7 +13,7 @@ class PolymorphicTest < ActiveSupport::TestCase
 
   test "does not archive polymorphic association of different item with same id" do
     archival = Archival.create!
-    another_polys_holder = AnotherPolysHolder.create! id: archival.id
+    another_polys_holder = AnotherPolysHolder.create!(id: archival.id)
     poly = another_polys_holder.polys.create!
     archival.archive!
 

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,4 +1,11 @@
 ActiveRecord::Schema.define(version: 1) do
+  create_table :another_polys_holders, force: true do |t|
+    t.column :name, :string
+    t.column :archival_id, :integer
+    t.column :archive_number, :string
+    t.column :archived_at, :datetime
+  end
+
   create_table :archivals, force: true do |t|
     t.column :name, :string
     t.column :archival_id, :integer

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,6 +50,7 @@ def create_test_tables
 end
 
 BASE_FIXTURE_CLASSES = [
+  :another_polys_holder,
   :archival,
   :archival_kid,
   :archival_grandkid,
@@ -79,9 +80,9 @@ def require_test_classes
   end
 
   fixtures = if ActiveRecord::VERSION::MAJOR >= 4
-               RAILS_5_FIXTURE_CLASSES + BASE_FIXTURE_CLASSES
+               RAILS_5_FIXTURE_CLASSES
              else
-               RAILS_4_FIXTURE_CLASSES + BASE_FIXTURE_CLASSES
+               RAILS_4_FIXTURE_CLASSES
              end
 
   fixtures += BASE_FIXTURE_CLASSES


### PR DESCRIPTION
If we have two models (with different tables) holding same has_many polymorphic association than archiving of one model object will archive associated models of another model object with same id. Association scope building was not taking type into account, relying only on id. This PR fixes that.