### PR TITLE
Add archive_all! and unarchive_all! methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ r.archived_at                    # => nil
 r.archived?                      # => false
 ```
 
+### Relations
+
+```ruby
+Hole.create!
+Hole.create!
+Hole.create!
+
+holes = Hole.all
+
+# All records in the relation will be archived with the same archive_number.
+# Dependent/Destroy relationships will be archived, and callbacks will still be honored.
+holes.archive_all!              # => [array of Hole records in the relation]
+
+holes.first.archive_number      # => "b56876de48a5dcfe71b2c13eec15e4a2"
+holes.last.archive_number       # => "b56876de48a5dcfe71b2c13eec15e4a2"
+
+holes.unarchive_all!            # => [array of Hole records in the relation]
+```
+
 ### Scopes
 
 ``` ruby
@@ -190,6 +209,7 @@ ActsAsParanoid and PermanentRecords were both inspirations for this:
 * Anthony Panozzo
 * Aaron Milam
 * Anton Rieder
+* Josh Menden
 
 Thanks!
 

--- a/lib/acts_as_archival.rb
+++ b/lib/acts_as_archival.rb
@@ -15,3 +15,5 @@ else
   ActiveRecord::Base.send :include, ExpectedBehavior::ActsAsArchival
   ActiveRecord::Base.send :include, ExpectedBehavior::ActsAsArchivalActiveRecordMethods
 end
+
+ActiveRecord::Relation.send :include, ExpectedBehavior::ActsAsArchivalActiveRecordMethods::ARRelationMethods

--- a/lib/expected_behavior/acts_as_archival_active_record_methods.rb
+++ b/lib/expected_behavior/acts_as_archival_active_record_methods.rb
@@ -36,5 +36,24 @@ module ExpectedBehavior
 
     end
 
+    module ARRelationMethods
+
+      def archive_all!
+        error_message = "The #{klass} must implement 'act_on_archivals' in order to call `archive_all!`"
+        raise NotImplementedError.new(error_message) unless archival?
+
+        head_archive_number = Digest::MD5.hexdigest("#{klass}#{Time.now.utc.to_i}")
+        each {|record| record.archive!(head_archive_number)}.tap { reset }
+      end
+
+      def unarchive_all!
+        error_message = "The #{klass} must implement 'act_on_archivals' in order to call `unarchive_all!`"
+        raise NotImplementedError.new(error_message) unless archival?
+
+        each(&:unarchive!).tap { reset }
+      end
+
+    end
+
   end
 end

--- a/test/relations_test.rb
+++ b/test/relations_test.rb
@@ -1,0 +1,69 @@
+require_relative "test_helper"
+
+class RelationsTest < ActiveSupport::TestCase
+
+  test "archive_all! archives all records in an AR Association" do
+    for i in 0..2 do
+      Archival.create!
+    end 
+
+    archivals = Archival.all
+    archivals.archive_all!
+    assert archivals.first.archived?
+    assert archivals.last.archived?
+  end
+
+  test "archive_all! archives all records with the same archival number" do
+    for i in 0..2 do
+      Archival.create!
+    end 
+
+    archivals = Archival.all
+    archivals.archive_all!
+    assert_equal archivals.first.archive_number, archivals.last.archive_number
+  end
+
+  test "archive_all! archives children records" do
+    for i in 0..2 do
+      parent = Archival.create!
+      for j in 0..1 do
+        parent.archivals.create!
+      end
+    end
+
+    parents = Archival.all
+    parents.archive_all!
+
+    assert parents.first.archivals.first.archived?
+    assert parents.first.archivals.last.archived?
+  end
+
+  test "unarchive_all! unarchives all records in an AR Assocation" do
+    for i in 0..2 do
+      Archival.create!
+    end 
+
+    archivals = Archival.all
+    archivals.archive_all!
+    archivals.unarchive_all!
+    assert_not archivals.first.archived?
+    assert_not archivals.last.archived?
+  end
+
+  test "unarchive_all! unarchives children records" do
+    for i in 0..2 do
+      parent = Archival.create!
+      for j in 0..1 do
+        parent.archivals.create!
+      end
+    end
+
+    parents = Archival.all
+    parents.archive_all!
+    parents.unarchive_all!
+
+    assert_not parents.first.archivals.first.archived?
+    assert_not parents.first.archivals.last.archived?
+  end
+
+end


### PR DESCRIPTION
Similar to the `destroy_all!` or `delete_all!` methods, we want to be able to call `archive_all!` and `unarchive_all!` on an ActiveRecord relation.