### PR TITLE
Fixing Rails 6.1 deprecation warning regarding "return"s within transactions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ gemfiles/*.lock
 pkg/*
 .DS_Store
 *.sqlite3
+.idea/

--- a/lib/expected_behavior/acts_as_archival.rb
+++ b/lib/expected_behavior/acts_as_archival.rb
@@ -133,15 +133,15 @@ module ExpectedBehavior
       end
 
       private def execute_archival_action(action)
+        result = false
         self.class.transaction do
           begin
-            success = run_callbacks(action) { yield }
-            return !!success
+            result = !!run_callbacks(action) { yield }
           rescue => e
             handle_archival_action_exception(e)
           end
         end
-        false
+        result
       end
 
       private def handle_archival_action_exception(exception)


### PR DESCRIPTION
Fixing "DEPRECATION WARNING: Using `return`, `break` or `throw` to exit a transaction block is deprecated without replacement.".

Repairs issue https://github.com/expectedbehavior/acts_as_archival/issues/46