### PR TITLE
Fix 'uninitialized constant ActiveRecord'

### DIFF
--- a/lib/acts_as_archival.rb
+++ b/lib/acts_as_archival.rb
@@ -1,3 +1,5 @@
+require "active_record"
+
 require "acts_as_archival/version"
 
 require "expected_behavior/association_operation/base"


### PR DESCRIPTION
Sidekiq fails dues to `acts_as_archival` uses ActiveRecord but never load it

https://github.com/sidekiq/sidekiq/issues/4766#issuecomment-2762824137


```
> bundle exec sidekiqswarm 
[swarm] Preloading Bundler groups ["default"]
bundler: failed to load command: sidekiqswarm (~/.rbenv/versions/3.4.2/bin/sidekiqswarm)
~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/acts_as_archival-2.1.0/lib/expected_behavior/acts_as_archival.rb:7:in '<module:ActsAsArchival>': uninitialized constant ExpectedBehavior::ActsAsArchival::ActiveRecord (NameError)

      MissingArchivalColumnError = Class.new(ActiveRecord::ActiveRecordError)
                                             ^^^^^^^^^^^^
Did you mean?  ActiveJob
        from ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/acts_as_archival-2.1.0/lib/expected_behavior/acts_as_archival.rb:2:in '<module:ExpectedBehavior>'
```